### PR TITLE
Update Dockerfile to use proper Pharo track repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/ba-st/pharo-loader:v10.0.1 AS loader
 ARG GROUP_NAMES=testRunner
-RUN pharo metacello install github://bajger/pharo-smalltalk:453-Build-Test-Runner/dev/src BaselineOfExercism --groups=$GROUP_NAMES
+RUN pharo metacello install github://exercism/pharo-smalltalk:main/releases/latest BaselineOfExercism --groups=$GROUP_NAMES
 RUN pharo eval --save "NoChangesLog install. \
     NoPharoFilesOpener install. \
     PharoCommandLineHandler forcePreferencesOmission: true. \


### PR DESCRIPTION
This is follow-up on: https://github.com/exercism/pharo-smalltalk/pull/563
Updated to proper repository name (instead of local branch)